### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@
 
    ```sh
    npx nuxi@latest module add tiptap
-
-   npx nuxi@latest module add tiptap
-
-   npx nuxi@latest module add tiptap
    ```
 
 2. Add `nuxt-tiptap-editor` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@
 1. Add `nuxt-tiptap-editor` dependency to your project
 
    ```sh
-   yarn add -D nuxt-tiptap-editor
+   npx nuxi@latest module add tiptap
 
-   npm install --save-dev nuxt-tiptap-editor
+   npx nuxi@latest module add tiptap
 
-   pnpm add -D nuxt-tiptap-editor
+   npx nuxi@latest module add tiptap
    ```
 
 2. Add `nuxt-tiptap-editor` to the `modules` section of `nuxt.config.ts`

--- a/docs/docs/quick-setup.md
+++ b/docs/docs/quick-setup.md
@@ -5,21 +5,9 @@ title: Quick Setup
 # Quick Setup
 
 1. Add `nuxt-tiptap-editor` dependency to your project
-
-   ::: code-group
-
-   ```sh [yarn]
-   yarn add -D nuxt-tiptap-editor
+   ```bash
+   npx nuxi@latest module add tiptap
    ```
-
-   ```sh [npm]
-   npm install --save-dev nuxt-tiptap-editor
-   ```
-
-   ```sh [pnpm]
-   pnpm add -D nuxt-tiptap-editor
-   ```
-   :::
 
 2. Add `nuxt-tiptap-editor` to the `modules` section of `nuxt.config.ts`
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
