### PR TITLE
fix: hoist tiptap vue types

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -125,6 +125,10 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.css = [...nuxt.options.css, ...customCSS]
 
+    nuxt.options.typescript = nuxt.options.typescript || {}
+    nuxt.options.typescript.hoist = nuxt.options.typescript.hoist || []
+    nuxt.options.typescript.hoist.push('@tiptap/vue-3')
+
     console.info('Tiptap Editor initialized')
   },
 })


### PR DESCRIPTION
using this, noticed that with pnpm the types for the components weren't coming through - that's because they rely on a dependency of this module.

`typescript.hoist` lets us tell the ide/volar about them