### PR TITLE
fix: update import paths for FloatingMenu and BubbleMenu in defaults.ts

### DIFF
--- a/src/imports/defaults.ts
+++ b/src/imports/defaults.ts
@@ -47,6 +47,6 @@ export const defaultImports: ImportObject[] = [
 
 export const defaultComponents: ImportObject[] = [
   { name: 'EditorContent', path: '@tiptap/vue-3' },
-  { name: 'FloatingMenu', path: '@tiptap/vue-3' },
-  { name: 'BubbleMenu', path: '@tiptap/vue-3' },
+  { name: 'FloatingMenu', path: '@tiptap/vue-3/menus' },
+  { name: 'BubbleMenu', path: '@tiptap/vue-3/menus' },
 ]


### PR DESCRIPTION
Without this fix, `BubbleMenu` and `FloatingMenu` components don't work correctly, causing runtime errors for users trying to use these features.