### PR TITLE
feat(lowlight): validate highlightJSVersion + opt-in SRI

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -82,11 +82,35 @@ export default defineNuxtModule<ModuleOptions>({
       const lldefaultTheme = options.lowlight?.theme || 'github-dark'
       const highlightJSVersion
         = options.lowlight?.highlightJSVersion || '11.10.0'
+
+      // Reject anything that isn't a clean semver — the version is
+      // interpolated into a `<link href>` and into a CDN URL, so let's
+      // refuse weird values rather than silently passing them through.
+      if (!/^\d+\.\d+\.\d+$/.test(highlightJSVersion)) {
+        throw new Error(
+          '[nuxt-tiptap-editor] Invalid `tiptap.lowlight.highlightJSVersion` '
+          + `value ${JSON.stringify(highlightJSVersion)}. Expected a semver `
+          + `string like "11.10.0".`,
+        )
+      }
+
       const llThemeCSS = `https://unpkg.com/@highlightjs/cdn-assets@${highlightJSVersion}/styles/${lldefaultTheme}.min.css`
+
+      const themeLink: Record<string, string> = {
+        rel: 'stylesheet',
+        href: llThemeCSS,
+      }
+      // Opt-in Subresource Integrity. SRI hashes can't be auto-derived at
+      // build without a network fetch, so consumers compute and supply the
+      // hash for the (theme, version) pair they care about.
+      if (options.lowlight?.integrity) {
+        themeLink.integrity = options.lowlight.integrity
+        themeLink.crossorigin = 'anonymous'
+      }
 
       nuxt.options.app.head.link = [
         ...(nuxt.options.app.head.link || []),
-        { rel: 'stylesheet', href: llThemeCSS },
+        themeLink,
       ]
     }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -281,11 +281,24 @@ export interface ModuleOptions {
       theme?: HighlightTheme
 
       /**
-       * highlight.js version used for css import
+       * highlight.js version used for css import. Must be a semver string
+       * like '11.10.0'; the value is validated at module setup.
        *
-       * @default '11.9.0'
+       * @default '11.10.0'
        */
-      highlightJSVersion?: '11.9.0' | string
+      highlightJSVersion?: string
+
+      /**
+       * Optional Subresource Integrity hash for the highlight.js theme
+       * stylesheet (the `<link>` injected into nuxt.options.app.head.link).
+       * When set, the link is rendered with `integrity` and
+       * `crossorigin="anonymous"`. Compute the hash for your specific
+       * (theme, version) pair — it cannot be derived without a network
+       * fetch.
+       *
+       * Example: `'sha384-...'`
+       */
+      integrity?: string
     }
 }
 

--- a/test/fixtures/lowlight-bad-version/app.vue
+++ b/test/fixtures/lowlight-bad-version/app.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <div data-testid="editor-status">
+      {{ editor ? 'ready' : 'loading' }}
+    </div>
+    <TiptapEditorContent
+      v-if="editor"
+      :editor="editor"
+      data-testid="editor-content"
+    />
+  </div>
+</template>
+
+<script setup>
+const lowlight = createLowlight(commonLanguages)
+
+const editor = useEditor({
+  content: '<pre><code class="language-javascript">const x = 1;</code></pre>',
+  extensions: [
+    TiptapStarterKit.configure({
+      codeBlock: false,
+    }),
+    TiptapCodeBlockLowlight.configure({
+      lowlight,
+    }),
+  ],
+})
+</script>

--- a/test/fixtures/lowlight-bad-version/nuxt.config.ts
+++ b/test/fixtures/lowlight-bad-version/nuxt.config.ts
@@ -1,0 +1,12 @@
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [MyModule],
+  tiptap: {
+    lowlight: {
+      theme: 'github-dark',
+      // Deliberately invalid — the module should refuse to set up.
+      highlightJSVersion: 'not-a-version',
+    },
+  },
+})

--- a/test/fixtures/lowlight-bad-version/package.json
+++ b/test/fixtures/lowlight-bad-version/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "lowlight-fixture",
+    "private": true
+}

--- a/test/fixtures/lowlight/nuxt.config.ts
+++ b/test/fixtures/lowlight/nuxt.config.ts
@@ -5,6 +5,9 @@ export default defineNuxtConfig({
   tiptap: {
     lowlight: {
       theme: 'github-dark',
+      // Example value used to assert the integrity flow wires up correctly;
+      // not a real hash for the github-dark stylesheet.
+      integrity: 'sha384-EXAMPLE-INTEGRITY-HASH',
     },
   },
 })

--- a/test/module-registration.test.ts
+++ b/test/module-registration.test.ts
@@ -119,9 +119,35 @@ describe('module registration — lowlight fixture', () => {
     expect(themeLink?.rel).toBe('stylesheet')
   })
 
+  it('renders integrity + crossorigin on the theme link when SRI is configured', () => {
+    const links = useTestContext().nuxt!.options.app.head.link ?? []
+    const themeLink = links.find(l =>
+      typeof l.href === 'string' && l.href.includes('highlightjs/cdn-assets'),
+    ) as Record<string, string> | undefined
+    expect(themeLink?.integrity).toBe('sha384-EXAMPLE-INTEGRITY-HASH')
+    expect(themeLink?.crossorigin).toBe('anonymous')
+  })
+
   it('still adds TipTap + lowlight packages to build.transpile', () => {
     const transpile = (useTestContext().nuxt!.options.build.transpile ?? []).map(String)
     expect(transpile).toContain('@tiptap/extension-code-block-lowlight')
     expect(transpile).toContain('lowlight')
   })
+})
+
+describe('module registration — invalid lowlight version', () => {
+  it('throws a descriptive error at module setup time', async () => {
+    setTestContext(createTestContext({
+      rootDir: fileURLToPath(
+        new URL('./fixtures/lowlight-bad-version', import.meta.url),
+      ),
+      build: true,
+      server: false,
+      browser: false,
+    }))
+    await expect(loadFixture()).rejects.toThrow(
+      /Invalid `tiptap\.lowlight\.highlightJSVersion`/,
+    )
+    setTestContext(undefined)
+  }, 60000)
 })


### PR DESCRIPTION
## Summary

The \`tiptap.lowlight.highlightJSVersion\` option was typed as \`string\` and interpolated unchecked into both a CDN URL and a \`<link href>\`. A malformed value would silently produce a broken link tag rather than failing fast at setup. Separately, no SRI hook existed for consumers who care about supply-chain integrity on the injected highlight.js stylesheet.

## What changed

- **Strict semver validation** on \`highlightJSVersion\` (\`/^\d+\.\d+\.\d+$/\`) at module setup. Bad values throw a clear error naming the offending input rather than silently producing a 404.
- **Opt-in SRI**: new \`tiptap.lowlight.integrity\` option. When provided, the injected \`<link>\` carries \`integrity\` + \`crossorigin=\"anonymous\"\`. Hashes can't be derived without a network fetch, so it stays opt-in.
- **JSDoc default fixed**: was '11.9.0', code is '11.10.0' — now agrees.
- Dropped the misleading \`'11.9.0' | string\` literal-or-string union (TypeScript collapses it to \`string\` anyway).

## Tests

- Added \`integrity\` to the existing lowlight fixture and a new assertion that the injected link carries \`integrity\` + \`crossorigin\".
- New \`test/fixtures/lowlight-bad-version/\` and a test asserting \`loadFixture()\` rejects with the expected error.

## Stacked branch

Stacked on **#29** → **#28** → **#27**. Merge order: #27 → #28 → #29 → #30.

## Test plan

- [x] \`pnpm test\` — 89/89 passing
- [x] \`pnpm test:types\` — clean
- [x] \`pnpm lint\` — clean
- [ ] Manual: boot playground with \`highlightJSVersion: 'bogus'\` → module setup throws with clear message
- [ ] Manual: boot playground with valid \`integrity\` → \`<link integrity=\"...\" crossorigin=\"anonymous\">\` in served HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)