### PR TITLE
chore: tighten release workflow + correct README pnpm/dev-prepare guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,9 @@ jobs:
           path: |
             .nuxt
             dist
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-build-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}-
             ${{ runner.os }}-build-
 
       - name: Run tests
@@ -100,8 +101,9 @@ jobs:
           path: |
             .nuxt
             dist
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-build-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}-
             ${{ runner.os }}-build-
 
       - name: Run dev:prepare

--- a/.github/workflows/ltpr.yml
+++ b/.github/workflows/ltpr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
@@ -30,19 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run linter
-        id: lint
-        run: pnpm lint || pnpm lint:fix
-
-      - name: Commit lint fixes
-        if: steps.lint.outcome == 'failure'
-        run: |
-          if [[ -n $(git status --porcelain) ]]; then
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add .
-            git commit -m "chore: fix lint errors"
-            git push
-          fi
+        run: pnpm lint
 
   test:
     runs-on: ubuntu-latest
@@ -56,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -71,8 +59,9 @@ jobs:
           path: |
             .nuxt
             dist
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-build-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}-
             ${{ runner.os }}-build-
 
       - name: Run tests
@@ -93,7 +82,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -140,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 

--- a/README.md
+++ b/README.md
@@ -184,10 +184,8 @@
      content: "<p>I'm running Tiptap with Vue.js. 🎉</p>",
      extensions: [TiptapStarterKit],
    });
-
-   onBeforeUnmount(() => {
-     unref(editor).destroy();
-   });
+   // TipTap 3 cleans up automatically when the component unmounts;
+   // no manual editor.destroy() call is needed.
    </script>
    ```
 
@@ -197,29 +195,53 @@ That's it! You can now use Nuxt TipTap Editor in your Nuxt app ✨
 
 ## Development
 
+This repo uses **pnpm** as the package manager.
+
 ```bash
 # Install dependencies
-yarn install
+pnpm install
 
-# Generate type stubs
-yarn dev:prepare
+# Generate type stubs (must be run after install and after structural changes in src/)
+pnpm dev:prepare
 
 # Develop with the playground
-yarn dev
+pnpm dev
 
 # Build the playground
-yarn build
+pnpm build
 
 # Run ESLint
-yarn lint
+pnpm lint
 
-# Run Vitest
-yarn test
-yarn test:watch
-
-# Release new version - needs to be with npm for login to work
-npm run release
+# Run Vitest (also runs vue-tsc --noEmit)
+pnpm test
+pnpm test:watch
 ```
+
+### Releasing
+
+Use the version-bump scripts (they trigger CI publish via OIDC):
+
+```bash
+pnpm release:patch   # 3.2.x → 3.2.(x+1)
+pnpm release:minor   # 3.2.x → 3.3.0
+pnpm release:major   # 3.x.y → 4.0.0
+```
+
+See [RELEASE.md](./RELEASE.md) for details.
+
+### Upgrading TipTap or Nuxt
+
+After bumping a major dependency, run the full suite — `pnpm test` and `pnpm test:types` will catch:
+- removed/renamed module APIs (registration tests)
+- broken extension behavior (command tests)
+- broken auto-import wiring (registration tests + smoke tests)
+- broken lowlight head-link injection
+
+Things the test suite cannot catch — please verify manually in `pnpm dev`:
+- BubbleMenu / FloatingMenu rendering and positioning
+- Drag/drop and paste flows in `playground/components/TipTapImage.vue`
+- Visual / CSS regressions
 
 ## Contribution
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,9 +45,9 @@ pnpm release:major
    - Publishes to npm
    - Creates a GitHub release
 
-## Manual Release (Legacy)
+## Manual Release (Legacy — deprecated)
 
-The original `pnpm release` command is still available if you prefer to handle versioning manually, but you'll need to update `package.json` and create tags yourself.
+The original `pnpm release` script (which directly publishes to npm from your machine) predates the OIDC trusted-publishing flow and **should not be used**. It bypasses the GitHub Actions release path, so the npm provenance signature won't be present and the GitHub release won't be created. Use one of the `release:patch / release:minor / release:major` scripts above instead. The legacy script will be removed in a future release.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Final PR in the priority-fixes stack. Two unrelated cleanups:
1. **Release workflow hygiene** — kill the auto-commit-on-lint-failure footgun, pin Node, fix cache key.
2. **README + RELEASE.md drift** — `yarn` → `pnpm`, document `dev:prepare` as the required first step, mark legacy `pnpm release` as deprecated, add an "Upgrading TipTap or Nuxt" section.

## What changed

### `.github/workflows/ltpr.yml`

- Drop \`pnpm lint || pnpm lint:fix\` + auto-commit step on the lint job. A tag-triggered release should fail loudly, not silently mutate \`main\` from a tag context (which races with the tag itself and pushes to a protected branch from an unusual ref).
- Pin Node to \`'22'\` everywhere (was \`'lts/*'\`).
- Cache key includes \`hashFiles('package.json', 'pnpm-lock.yaml')\` so consecutive commits and dependency bumps interact cleanly with the cache.

### `.github/workflows/ci.yml`

- Same cache-key improvement.

### `README.md`

- \`yarn\` → \`pnpm\` throughout the Development section.
- \`pnpm dev:prepare\` documented as the required first step.
- Drop the misleading \`unref(editor).destroy()\` example footer (TipTap 3 unmounts automatically).
- New "Releasing" subsection pointing at \`release:patch/minor/major\`.
- New "Upgrading TipTap or Nuxt" subsection listing what the test suite catches automatically (registration tests, command tests, lowlight head-link assertions) and what still needs manual playground smoke testing (BubbleMenu, FloatingMenu, drag+drop, CSS).

### `RELEASE.md`

- Mark legacy \`pnpm release\` script as deprecated. It bypasses the OIDC trusted-publishing path, so npm provenance and the GitHub release are skipped. Removal in next major.

## Stacked branch

Stacked on **#30** → **#29** → **#28** → **#27**. Merge order: #27 → #28 → #29 → #30 → #31.

## Test plan

- [x] \`pnpm test\` — 89/89 passing
- [x] \`pnpm test:types\` — clean
- [x] \`pnpm lint\` — clean
- [ ] Push a dummy tag against a fork to verify \`ltpr.yml\` runs without the auto-commit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)