### PR TITLE
fix: dedupe ProseMirror packages to prevent duplicate-instance errors

### DIFF
--- a/docs/docs/important.md
+++ b/docs/docs/important.md
@@ -59,3 +59,19 @@ onBeforeUnmount(() => {
   unref(editor).destroy();
 });
 ```
+
+## "Adding different instances of a keyed plugin" / `localsInner` errors
+
+If you see `RangeError: Adding different instances of a keyed plugin (plugin$)` or `Cannot read properties of undefined (reading 'localsInner')`, your build has loaded **two copies of ProseMirror**. This happens when you install a TipTap extension directly (e.g. `@tiptap/extension-placeholder`) alongside the ones this module provides, and the bundler resolves a second `prosemirror-state`/`prosemirror-view`.
+
+As of v3.4.0 the module deduplicates the ProseMirror packages automatically via `vite.resolve.dedupe`, so this should no longer occur. If you still hit it (e.g. with a non-default builder), add the same dedupe to your `nuxt.config`:
+
+```ts
+export default defineNuxtConfig({
+  vite: {
+    resolve: {
+      dedupe: ['prosemirror-state', 'prosemirror-view', 'prosemirror-model'],
+    },
+  },
+});
+```

--- a/src/module.ts
+++ b/src/module.ts
@@ -11,6 +11,24 @@ import type { ModuleOptions, ImportObject } from './types'
 
 import * as allImports from './imports'
 
+// The ProseMirror packages re-exported through `@tiptap/pm`. They must
+// resolve to a single instance across the consumer app and every TipTap
+// extension, otherwise mixing module-provided and directly-installed
+// extensions duplicates them and breaks the editor at runtime.
+const proseMirrorPackages = [
+  'prosemirror-state',
+  'prosemirror-view',
+  'prosemirror-model',
+  'prosemirror-transform',
+  'prosemirror-commands',
+  'prosemirror-keymap',
+  'prosemirror-schema-list',
+  'prosemirror-history',
+  'prosemirror-gapcursor',
+  'prosemirror-dropcursor',
+  'prosemirror-inputrules',
+]
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name,
@@ -175,6 +193,25 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.typescript = nuxt.options.typescript || {}
     nuxt.options.typescript.hoist = nuxt.options.typescript.hoist || []
     nuxt.options.typescript.hoist.push('@tiptap/vue-3')
+
+    // Force a single copy of every ProseMirror package. When a consumer also
+    // installs @tiptap/* extensions directly (e.g. Placeholder), Vite can
+    // bundle a second copy of prosemirror-state/view, which throws
+    // "Adding different instances of a keyed plugin (plugin$)" and breaks
+    // decoration rendering ("Cannot read properties of undefined (reading
+    // 'localsInner')"). Deduping + pre-bundling them collapses it to one
+    // instance. See ueberdosis/tiptap#5267, #3869.
+    nuxt.options.vite = nuxt.options.vite || {}
+    nuxt.options.vite.resolve = nuxt.options.vite.resolve || {}
+    nuxt.options.vite.resolve.dedupe = [
+      ...(nuxt.options.vite.resolve.dedupe || []),
+      ...proseMirrorPackages,
+    ]
+    nuxt.options.vite.optimizeDeps = nuxt.options.vite.optimizeDeps || {}
+    nuxt.options.vite.optimizeDeps.include = [
+      ...(nuxt.options.vite.optimizeDeps.include || []),
+      ...proseMirrorPackages,
+    ]
 
     console.info('Tiptap Editor initialized')
   },

--- a/test/module-registration.test.ts
+++ b/test/module-registration.test.ts
@@ -30,6 +30,16 @@ const PACKAGES_TRANSPILED = [
   '@tiptap/extension-link',
 ]
 
+// A consumer who also installs @tiptap/* extensions directly can end up with
+// two copies of these resolved into the bundle, which throws "Adding
+// different instances of a keyed plugin" / breaks decorations
+// ('localsInner'). The module pins them via vite.resolve.dedupe.
+const PROSEMIRROR_DEDUPE = [
+  'prosemirror-state',
+  'prosemirror-view',
+  'prosemirror-model',
+]
+
 const FIXTURES = {
   basic: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
   customPrefix: fileURLToPath(
@@ -77,6 +87,13 @@ describe('module registration — default fixture (prefix=Tiptap)', () => {
       typeof l.href === 'string' && l.href.includes('highlightjs/cdn-assets'),
     )
     expect(hjs).toBeUndefined()
+  })
+
+  it('dedupes ProseMirror packages via vite.resolve.dedupe', () => {
+    const dedupe = useTestContext().nuxt!.options.vite?.resolve?.dedupe ?? []
+    for (const pkg of PROSEMIRROR_DEDUPE) {
+      expect(dedupe).toContain(pkg)
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

Two open issues, same root cause — **two copies of ProseMirror** in the bundle:

- #20 — `RangeError: Adding different instances of a keyed plugin (plugin$)` (image upload / Placeholder)
- #15 — `Cannot read properties of undefined (reading 'localsInner')` (CodeBlockLowlight + Placeholder)

This happens when a consumer installs a TipTap extension directly (e.g. `@tiptap/extension-placeholder`) alongside the module-provided ones, and the bundler resolves a second `prosemirror-state`/`prosemirror-view`. It's a well-known TipTap/Vite issue (ueberdosis/tiptap#5267, #3869).

## Fix

Pin every ProseMirror package to a single instance via `vite.resolve.dedupe` + `vite.optimizeDeps.include` in the module setup, so module-provided and directly-installed extensions share one copy. No consumer config required.

## Tests

- New registration test asserts `vite.resolve.dedupe` includes the ProseMirror packages.
- Full suite: **90 passing**; `test:types` and `lint` green.

## Docs

Added a troubleshooting section to `docs/docs/important.md`.

Closes #15, closes #20.