### PR TITLE
docs: order sidebar pages by reading order

### DIFF
--- a/docs/auto-imports.md
+++ b/docs/auto-imports.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 5
 title: Auto-imports Reference
 description: Every composable, component, node, mark, and extension the module registers, and the name it's available under.
 ---

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 8
 title: Contribution
 description: How to contribute to Nuxt Tiptap Editor.
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 7
 title: Development
 description: Run, test, and release Nuxt Tiptap Editor locally.
 ---

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 1
 title: Basic Example
 description: The minimal editor component with a formatting toolbar.
 ---

--- a/docs/examples/image-upload.md
+++ b/docs/examples/image-upload.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 5
 title: Image Upload Example
 description: Use the built-in image-upload extension with paste, drag-and-drop, and a server upload route.
 ---

--- a/docs/examples/lowlight.md
+++ b/docs/examples/lowlight.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 3
 title: Code Block Highlighter Example
 description: Enable the lowlight option for syntax-highlighted code blocks.
 ---

--- a/docs/examples/placeholder.md
+++ b/docs/examples/placeholder.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 4
 title: Placeholder Example
 description: Use the external Placeholder extension to show hint text in an empty editor.
 ---

--- a/docs/examples/prefill-content.md
+++ b/docs/examples/prefill-content.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 2
 title: Pre-fill Content Example
 description: Set the editor's content during initialization or at any time with setContent.
 ---

--- a/docs/extensions.mdx
+++ b/docs/extensions.mdx
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 4
 title: Extensions
 description: Which Tiptap extensions ship with the module, and how to add your own.
 ---

--- a/docs/important.md
+++ b/docs/important.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 3
 title: Important Points
 description: Client-only editor instances, automatic cleanup, SSR behaviour, and the ProseMirror dedupe fix.
 ---

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 6
 title: Menus
 description: Use the auto-registered bubble and floating menu components for contextual editor toolbars.
 ---

--- a/docs/quick-setup.mdx
+++ b/docs/quick-setup.mdx
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 2
 title: Quick Setup
 description: Install the module, register it in nuxt.config, and render your first Tiptap editor.
 ---

--- a/docs/what-is.md
+++ b/docs/what-is.md
@@ -1,4 +1,6 @@
 ---
+sidebar:
+  order: 1
 title: What is Nuxt Tiptap Editor?
 description: Why this module exists and what it does for your Nuxt app.
 ---


### PR DESCRIPTION
Adds `sidebar.order` frontmatter so docs pages render in reading order (What is → Quick Setup → Important → Extensions → Auto-imports → Menus → Development → Contribution) and examples in a sensible order, instead of alphabetical. Fixes the near-empty Contribution page leading the list. The hub sidebar builder sorts root pages by this order; the Examples subgroup uses Starlight autogenerate which honors it natively.